### PR TITLE
Test backoffice os fix

### DIFF
--- a/.github/workflows/test-backoffice.yml
+++ b/.github/workflows/test-backoffice.yml
@@ -63,6 +63,7 @@ jobs:
             docker run
             --pull always
             --network=host
+            --entrypoint poetry
             --env DJANGO_SETTINGS_MODULE=config.settings.test
             --env DISABLE_SECURITY_PLUGIN=true
             --env POSTGRES_DB=inspire
@@ -71,4 +72,4 @@ jobs:
             --env POSTGRES_HOST=127.0.0.1
             --env OPENSEARCH_HOST=127.0.0.1:9200
             registry.cern.ch/cern-sis/inspire/backoffice@${{ needs.build.outputs.image-id }}
-            sh -c "poetry run python manage.py opensearch index create --force && poetry run pytest"
+            run pytest"

--- a/backoffice/config/settings/test.py
+++ b/backoffice/config/settings/test.py
@@ -34,7 +34,7 @@ TEMPLATES[0]["OPTIONS"]["debug"] = True  # type: ignore # noqa: F405
 # MEDIA
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = "http://media.testserver"
+MEDIA_URL = "http://media.testserver/"
 # Opensearch
 # ------------------------------------------------------------------------------
 # Name of the Opensearch index


### PR DESCRIPTION
Tested Locally and working the MEDIA_URL should end with the slash. As described in the documentation: https://docs.djangoproject.com/fr/5.0/ref/settings/#std-setting-MEDIA_URL

My guess for this error ocurring is that when running `python manage ...` a few checks were done that were not previously being done.