### PR TITLE
restart-workflows-fix

### DIFF
--- a/backoffice/backoffice/workflows/airflow_utils.py
+++ b/backoffice/backoffice/workflows/airflow_utils.py
@@ -11,7 +11,6 @@ from backoffice.workflows.constants import WORKFLOW_DAGS
 AIRFLOW_BASE_URL = environ.get("AIRFLOW_BASE_URL")
 
 AIRFLOW_HEADERS = {
-    "Content-Type": "application/json",
     "Authorization": f"Basic {environ.get('AIRFLOW_TOKEN')}",
 }
 
@@ -140,10 +139,7 @@ def delete_workflow_dag(dag_id, workflow_id):
             dag_id,
             url,
         )
-        response = requests.delete(
-            url,
-            headers=AIRFLOW_HEADERS,
-        )
+        response = requests.delete(url, headers=AIRFLOW_HEADERS)
         response.raise_for_status()
         return JsonResponse({"message": "Successfully deleted DAG"})
     except RequestException:


### PR DESCRIPTION
Issue was, the DELETE request needed a `data` field for it to work as we set the `"Content-Type": "application/json"`

Fix:
Since the `requests` library automatically adds `"Content-Type": "application/json"` if the data field is present. I removed this field from the default headers