### PR TITLE
enhance workflow search

### DIFF
--- a/backoffice/backoffice/workflows/api/views.py
+++ b/backoffice/backoffice/workflows/api/views.py
@@ -257,14 +257,17 @@ class WorkflowDocumentView(BaseDocumentViewSet):
         OrderingFilterBackend,
     ]
     search_fields = {
-        "workflow_type",
-        "status",
-        "is_update",
+        "data.ids.value",
+        "data.ids.schema",
+        "data.name.value",
+        "data.name.preferred_name",
+        "data.email_addresses.value",
     }
 
     filter_fields = {
         "status": "status",
         "workflow_type": "workflow_type",
+        "is_update": "is_update"
     }
 
     ordering_fields = {"_updated_at": "_updated_at"}

--- a/backoffice/backoffice/workflows/documents.py
+++ b/backoffice/backoffice/workflows/documents.py
@@ -9,7 +9,28 @@ from backoffice.workflows.models import Workflow
 class WorkflowDocument(Document):
     id = fields.TextField()
     workflow_type = fields.KeywordField()
-    data = fields.ObjectField()
+    data = fields.ObjectField(
+        properties={
+            "ids": fields.ObjectField(
+                properties={
+                    "value": fields.KeywordField(),
+                    "schema": fields.KeywordField(),
+                }
+            ),
+            "name": fields.ObjectField(
+                properties={
+                    "value": fields.TextField(),
+                    "preferred_name": fields.TextField(),
+                }
+            ),
+            "email_address": fields.ObjectField(
+                properties={
+                    "value": fields.KeywordField(),
+                    "current": fields.BooleanField(),
+                }
+            )
+        }
+    )
     status = fields.KeywordField()
     is_update = fields.BooleanField()
 

--- a/backoffice/backoffice/workflows/tests/test_views.py
+++ b/backoffice/backoffice/workflows/tests/test_views.py
@@ -382,15 +382,60 @@ class TestWorkflowSearchFilterViewSet(BaseTransactionTestCase):
     def setUp(self):
         super().setUp()
 
-        Workflow.objects.create(
-            data={},
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Workflow.objects.update_or_create(
+            data={
+                "ids": [
+                    {
+                        "value": "0000-0003-3302-3333",
+                        "schema": "ORCID"
+                    },
+                    {
+                        "value": "CastleFrank",
+                        "schema": "INSPIRE BAI"
+                    }
+                ],
+                "name": {
+                    "value": "Castle, Frank",
+                    "preferred_name": "Frank Castle"
+                },
+                "email_addresses": [
+                    {
+                        "value": "frank.castle@someting.ch",
+                        "current": True
+                    }
+                ]
+            },
             status=StatusChoices.APPROVAL,
             core=True,
             is_update=False,
             workflow_type=WorkflowType.AUTHOR_CREATE,
         )
-        Workflow.objects.create(
-            data={},
+        Workflow.objects.update_or_create(
+            data={
+                "ids": [
+                    {
+                        "value": "0000-0003-3302-2222",
+                        "schema": "ORCID"
+                    },
+                    {
+                        "value": "SmithJohn",
+                        "schema": "INSPIRE BAI"
+                    }
+                ],
+                "name": {
+                    "value": "Smith, John",
+                    "preferred_name": "John Smith"
+                },
+                "email_addresses": [
+                    {
+                        "value": "john.smith@someting.ch",
+                        "current": True
+                    }
+                ]
+            },
             status=StatusChoices.RUNNING,
             core=True,
             is_update=False,
@@ -405,32 +450,16 @@ class TestWorkflowSearchFilterViewSet(BaseTransactionTestCase):
         assert "_filter_status" in response.json()["facets"]
         assert "_filter_workflow_type" in response.json()["facets"]
 
-    def test_search_status(self):
+    def test_search_data_name(self):
         self.api_client.force_authenticate(user=self.admin)
 
-        url = (
-            reverse("search:workflow-list") + f"?search=status:{StatusChoices.RUNNING}"
-        )
+        url = reverse("search:workflow-list") + "?search=John"
 
         response = self.api_client.get(url)
+        results = response.json()["results"]
 
-        for item in response.json()["results"]:
-            print(item["status"])
-            assert item["status"] == StatusChoices.RUNNING
-
-    def test_search_workflow_type(self):
-        self.api_client.force_authenticate(user=self.admin)
-
-        url = (
-            reverse("search:workflow-list")
-            + f"?search=workflow_type:{WorkflowType.HEP_CREATE}"
-        )
-
-        response = self.api_client.get(url)
-
-        for item in response.json()["results"]:
-            print(item["workflow_type"])
-            assert item["workflow_type"] == WorkflowType.HEP_CREATE
+        assert len(results) == 1
+        assert results[0]["data"]["name"]["value"] == "Smith, John"
 
     def test_filter_status(self):
         self.api_client.force_authenticate(user=self.admin)


### PR DESCRIPTION
* Search was not working since the boolean field `is_update` was causing issues (for some reason whatever you wrote as `?search=...` would always be parsed as boolean).
* Added more fields to `search_fields`, removed `workflow_type` and `status`, and moved `is_update` to `filter_fields`.
* Modified document mapping to include `data`'s content.