### PR TITLE
airflow wf: close curation not working fix

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -51,7 +51,7 @@ jobs:
           -v "$(pwd)"/tests:/opt/airflow/tests
           -v "$(pwd)"/requirements-test.txt:/opt/airflow/requirements-test.txt
           -v "$(pwd)"/data:/opt/airflow/data
-          -v "$(pwd)"/scripts/variables/variables.json:/opt/airflow/variables.json
+          -v "$(pwd)"/scripts:/opt/airflow/scripts
           -e AIRFLOW__CORE__EXECUTOR=CeleryExecutor
           -e AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@127.0.0.1:5432/airflow
           -e AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql://airflow:airflow@127.0.0.1:5432/airflow
@@ -61,4 +61,4 @@ jobs:
           -e AIRFLOW__CORE__LOAD_EXAMPLES="false"
           -e AIRFLOW__API__AUTH_BACKENDS="airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session"
           registry.cern.ch/cern-sis/inspire/workflows@${{ needs.build.outputs.image-id }}
-          bash -c "pip install -r requirements-test.txt && airflow db init && airflow variables import /opt/airflow/variables.json && pytest /opt/airflow/tests"
+          bash -c "pip install -r requirements-test.txt && airflow db init && airflow connections import /opt/airflow/scripts/connections/connections.json && airflow variables import /opt/airflow/scripts/variables/variables.json && pytest /opt/airflow/tests"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ x-airflow-common: &airflow-common
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres-airflow/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ""
-    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "false"
     AIRFLOW__CORE__LOAD_EXAMPLES: "false"
     AIRFLOW__API__AUTH_BACKENDS: "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session"
     AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: "true" # used when modifying plugins

--- a/workflows/dags/author/author_create/author_create_approved.py
+++ b/workflows/dags/author/author_create/author_create_approved.py
@@ -3,7 +3,7 @@ import logging
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from airflow.utils.trigger_rule import TriggerRule
+from author.author_create.shared_tasks import close_author_create_user_ticket
 from hooks.backoffice.workflow_management_hook import AUTHORS, WorkflowManagementHook
 from hooks.backoffice.workflow_ticket_management_hook import (
     WorkflowTicketManagementHook,
@@ -118,16 +118,6 @@ def author_create_approved_dag():
             return "author_check_approval_branch"
         else:
             return "set_author_create_workflow_status_to_error"
-
-    @task(trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
-    def close_author_create_user_ticket(**context: dict) -> None:
-        ticket_type = "author_create_user"
-        ticket_id = workflow_ticket_management_hook.get_ticket(
-            workflow_id=context["params"]["workflow_id"], ticket_type=ticket_type
-        )["ticket_id"]
-        endpoint = "api/tickets/resolve"
-        request_data = {"ticket_id": ticket_id}
-        inspire_http_hook.call_api(endpoint=endpoint, data=request_data, method="POST")
 
     @task()
     def set_author_create_workflow_status_to_completed(**context: dict) -> None:

--- a/workflows/dags/author/author_create/author_create_rejected.py
+++ b/workflows/dags/author/author_create/author_create_rejected.py
@@ -2,11 +2,8 @@ import datetime
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
+from author.author_create.shared_tasks import close_author_create_user_ticket
 from hooks.backoffice.workflow_management_hook import AUTHORS, WorkflowManagementHook
-from hooks.backoffice.workflow_ticket_management_hook import (
-    WorkflowTicketManagementHook,
-)
-from hooks.inspirehep.inspire_http_hook import InspireHttpHook
 from include.utils.set_workflow_status import set_workflow_status_to_error
 
 
@@ -31,19 +28,7 @@ def author_create_rejected_dag() -> None:
     2. set_author_create_workflow_status_to_completed: Sets the status of
         the author creation workflow to 'completed'.
     """
-    inspire_http_hook = InspireHttpHook()
     workflow_management_hook = WorkflowManagementHook()
-    workflow_ticket_management_hook = WorkflowTicketManagementHook()
-
-    @task()
-    def close_author_create_user_ticket(**context: dict) -> None:
-        ticket_type = "author_create_user"
-        ticket_id = workflow_ticket_management_hook.get_ticket(
-            workflow_id=context["params"]["workflow_id"], ticket_type=ticket_type
-        )["ticket_id"]
-        endpoint = "/tickets/resolve"  # TODO: the URL for resolving dag will change
-        request_data = {"ticket_id": ticket_id}
-        inspire_http_hook.call_api(endpoint=endpoint, data=request_data, method="POST")
 
     @task()
     def set_author_create_workflow_status_to_completed(**context: dict) -> None:

--- a/workflows/dags/author/author_create/shared_tasks.py
+++ b/workflows/dags/author/author_create/shared_tasks.py
@@ -1,0 +1,17 @@
+from airflow.decorators import task
+from airflow.utils.trigger_rule import TriggerRule
+from hooks.backoffice.workflow_ticket_management_hook import (
+    WorkflowTicketManagementHook,
+)
+from hooks.inspirehep.inspire_http_hook import InspireHttpHook
+
+
+@task(trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+def close_author_create_user_ticket(**context: dict) -> None:
+    ticket_type = "author_create_user"
+    ticket_id = WorkflowTicketManagementHook().get_ticket(
+        workflow_id=context["params"]["workflow_id"], ticket_type=ticket_type
+    )["ticket_id"]
+    endpoint = "api/tickets/resolve"
+    request_data = {"ticket_id": ticket_id}
+    InspireHttpHook().call_api(endpoint=endpoint, data=request_data, method="POST")

--- a/workflows/requirements-test.txt
+++ b/workflows/requirements-test.txt
@@ -1,3 +1,5 @@
 pytest
 coverage
 pytest-cov
+pytest-vcr==1.0.2
+vcrpy==6.0.1

--- a/workflows/tests/cassettes/TestAuthorCreate.test_close_author_create_user_ticket.yaml
+++ b/workflows/tests/cassettes/TestAuthorCreate.test_close_author_create_user_ticket.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token 2e04111a61e8f5ba6ecec52af21bbb9e81732085
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://host.docker.internal:8000/api/workflow-ticket/f8301c06-8fa1-4124-845e-c270b910af5f/?ticket_type=author_create_user
+  response:
+    body:
+      string: '{"id":1,"ticket_url":"https://cerntraining.service-now.com/nav_to.do?uri=/u_request_fulfillment.do?sys_id=656f2d17878c929095f833340cbb3531","ticket_id":"656f2d17878c929095f833340cbb3531","ticket_type":"author_create_user","workflow_id":"f8301c06-8fa1-4124-845e-c270b910af5f"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '275'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 21 Aug 2024 11:06:38 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - WSGIServer/0.2 CPython/3.11.6
+      Vary:
+      - Accept, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ticket_id=656f2d17878c929095f833340cbb3531
+    headers:
+      Accept:
+      - application/vnd+inspire.record.raw+json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer cZiS4W7K8sqyebkxQzpnSwuUKLr5Ne6qPfnoOAjP7M2IvHxQhKmwiCJpp2QC
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '42'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://inspirebeta.net/api/tickets/resolve
+  response:
+    body:
+      string: '{"message":"Ticket resolved"}
+
+        '
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - Content-Type, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+      content-length:
+      - '30'
+      content-type:
+      - application/json
+      date:
+      - Wed, 21 Aug 2024 11:06:39 GMT
+      server:
+      - gunicorn/19.10.0
+      x-proxy-backend:
+      - inspire-qa_hep-web_http
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/workflows/tests/test_author_create_tasks.py
+++ b/workflows/tests/test_author_create_tasks.py
@@ -1,0 +1,17 @@
+import pytest
+from dags.author.author_create.shared_tasks import (
+    close_author_create_user_ticket,
+)
+
+
+class TestAuthorCreate:
+    context = {
+        "params": {
+            "workflow_id": "f8301c06-8fa1-4124-845e-c270b910af5f",
+            "data": {"value": "reject", "create_ticket": False},
+        }
+    }
+
+    @pytest.mark.vcr()
+    def test_close_author_create_user_ticket(self):
+        close_author_create_user_ticket.function(**self.context)


### PR DESCRIPTION
`/tickets/resolve` was being called instead of `api/tickets/resolve`.
Since the task was the exact same for the `approve` and `reject` task, took the opportunity merge the task into one.

Test will be failing until changes in https://github.com/inspirehep/backoffice/pull/76 are merged