### PR TITLE
backoffice: ordering by best match added 

### DIFF
--- a/backoffice/backoffice/workflows/api/views.py
+++ b/backoffice/backoffice/workflows/api/views.py
@@ -272,9 +272,9 @@ class WorkflowDocumentView(BaseDocumentViewSet):
         "is_update": "is_update",
     }
 
-    ordering_fields = {"_updated_at": "_updated_at"}
+    ordering_fields = {"_updated_at": "_updated_at", "_score": "_score"}
 
-    ordering = ("-_updated_at",)
+    ordering = ("-_updated_at", "-_score")
 
     faceted_search_fields = {
         "status": {


### PR DESCRIPTION
According to the documentation all its required is to add a score field in the ordering
https://django-elasticsearch-dsl-drf.readthedocs.io/en/latest/faq.html?highlight=score#questions-and-answers

it is working
